### PR TITLE
feat: add Notion-backed dashboard on GitHub Pages

### DIFF
--- a/.github/workflows/sync-notion.yml
+++ b/.github/workflows/sync-notion.yml
@@ -1,0 +1,48 @@
+name: Sync Notion data
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - "scripts/fetch_notion.py"
+      - ".github/workflows/sync-notion.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-notion
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Fetch Notion data
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_PAGE_ID: ${{ secrets.NOTION_PAGE_ID }}
+        run: python scripts/fetch_notion.py
+
+      - name: Commit data.json if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- docs/data.json; then
+            echo "Sin cambios en docs/data.json"
+            exit 0
+          fi
+          git add docs/data.json
+          git commit -m "chore: sync Notion data ($(date -u +%Y-%m-%dT%H:%MZ))"
+          git push

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,108 @@
+# Setup del Dashboard de Notion en GitHub Pages
+
+Pasos manuales que **tú** tienes que hacer una sola vez. El código ya está listo en el repo.
+
+URL final del dashboard: **https://eliascalixto.github.io/monitor/**
+
+---
+
+## 1. Crear la integración en Notion
+
+1. Abre <https://www.notion.so/profile/integrations>.
+2. Click en **+ New integration**.
+3. Nombre: `Monitor Dashboard` (o el que quieras).
+4. Associated workspace: el workspace donde vive tu página Monitor.
+5. Type: **Internal**.
+6. Click **Save**.
+7. En la pestaña **Configuration** copia el **Internal Integration Secret** (empieza con `secret_` o `ntn_`). Guárdalo, lo necesitarás en el paso 3.
+
+## 2. Compartir tu página Monitor con la integración
+
+> Sin esto la API te devuelve 404 porque la integración no ve la página.
+
+1. Abre tu página **Monitor** en Notion.
+2. Arriba a la derecha click en `···` → **Connections** (o "Conexiones").
+3. Busca el nombre de tu integración (`Monitor Dashboard`) y dale acceso.
+4. La integración hereda permiso a **todas** las sub-páginas y databases hijas.
+
+### Obtener el Page ID
+
+La URL de tu página se ve así:
+
+```
+https://www.notion.so/Monitor-1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+```
+
+El page ID son los **últimos 32 caracteres hex** (con o sin guiones). En el ejemplo: `1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d`. Cópialo.
+
+## 3. Agregar los secrets en GitHub
+
+1. Ve a <https://github.com/EliasCalixto/monitor/settings/secrets/actions>.
+2. Click **New repository secret** y crea estos dos:
+
+   | Name             | Value                                                    |
+   | ---------------- | -------------------------------------------------------- |
+   | `NOTION_TOKEN`   | El secret de tu integración (paso 1)                     |
+   | `NOTION_PAGE_ID` | El page ID de Monitor (paso 2)                           |
+
+## 4. Permitir que el workflow haga push
+
+1. Ve a <https://github.com/EliasCalixto/monitor/settings/actions>.
+2. Baja hasta **Workflow permissions**.
+3. Selecciona **Read and write permissions**.
+4. Guarda.
+
+> Si no haces esto, el workflow corre pero falla al hacer `git push` con error 403.
+
+## 5. Correr el workflow por primera vez
+
+1. Ve a <https://github.com/EliasCalixto/monitor/actions/workflows/sync-notion.yml>.
+2. Click **Run workflow** → branch `main` → **Run workflow**.
+3. Espera ~30 seg. Cuando termine en verde, debería haber un nuevo commit `chore: sync Notion data ...` en `main` actualizando `docs/data.json`.
+
+A partir de aquí corre automáticamente cada 15 minutos.
+
+## 6. Activar GitHub Pages
+
+1. Ve a <https://github.com/EliasCalixto/monitor/settings/pages>.
+2. Source: **Deploy from a branch**.
+3. Branch: `main` · Folder: `/docs`.
+4. Click **Save**.
+5. Espera ~1 minuto y abre <https://eliascalixto.github.io/monitor/>.
+
+---
+
+## Probar local antes de hacer push
+
+```powershell
+# Carga tu token a la sesion (NO lo escribas en archivos)
+$env:NOTION_TOKEN = "secret_xxx..."
+$env:NOTION_PAGE_ID = "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d"
+
+python scripts/fetch_notion.py
+```
+
+Esto genera `docs/data.json` localmente. Después sirve `docs/` con cualquier servidor estático:
+
+```powershell
+# Python tiene un servidor built-in
+python -m http.server -d docs 8000
+```
+
+Y abre <http://localhost:8000>.
+
+---
+
+## Troubleshooting
+
+- **`object_not_found` o 404 en el workflow** → no compartiste la página con la integración (paso 2).
+- **El dashboard muestra "No se encontraron databases"** → las databases hijas no son inline; muévelas dentro de la página Monitor o ejecuta el script y revisa `docs/data.json` para ver qué encontró.
+- **El workflow corre pero no commitea** → no diste write permission (paso 4) o `data.json` no cambió.
+- **Las páginas no se actualizan** → GitHub Pages cachea ~10 min. Fuerza recarga con Ctrl+F5.
+- **No quieres esperar 15 min entre updates** → edita el cron en `.github/workflows/sync-notion.yml`. El mínimo práctico en GitHub Actions gratis es ~5 min (`*/5 * * * *`).
+
+## Notas de seguridad
+
+- El `data.json` es **público** (cualquiera con la URL del Pages lo puede leer). No publiques databases con info privada.
+- Si necesitas privacidad: cambia el repo a privado y usa **GitHub Pages Private** (requiere plan Pro/Team) o migra a Cloudflare Pages con auth.
+- Si filtras el token por accidente: regrésate a la página de integraciones de Notion y haz **Regenerate** del secret.

--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1,0 +1,479 @@
+const PALETTE = [
+  "#8dbad6", "#9bc2e7", "#8ea9db", "#abb9d4",
+  "#b9f5c4", "#fd9a9a", "#f8ccad", "#fef2cb",
+  "#c4a7e7", "#a7c4e7", "#e7a7c4", "#a7e7c4",
+];
+
+const REPO_URL = "https://github.com/EliasCalixto/monitor";
+
+const state = {
+  data: null,
+  currentDb: null,
+  search: "",
+  sortKey: null,
+  sortDir: 1,
+  chart1: null,
+  chart2: null,
+};
+
+const $ = (sel) => document.querySelector(sel);
+
+function setStatus(msg, isError = false) {
+  const el = $("#status");
+  if (!msg) {
+    el.classList.remove("show");
+    return;
+  }
+  el.textContent = msg;
+  el.classList.toggle("error", isError);
+  el.classList.add("show");
+  if (!isError) setTimeout(() => el.classList.remove("show"), 3500);
+}
+
+async function loadData() {
+  setStatus("Cargando data.json…");
+  try {
+    const res = await fetch(`./data.json?ts=${Date.now()}`, { cache: "no-store" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    state.data = data;
+    onDataReady();
+    setStatus("");
+  } catch (e) {
+    console.error(e);
+    setStatus(
+      "No se pudo cargar data.json. ¿Ya corrió el workflow 'Sync Notion data'? Ve a Actions y ejecútalo manualmente la primera vez.",
+      true,
+    );
+  }
+}
+
+function onDataReady() {
+  const { databases, generated_at } = state.data;
+  if (generated_at) {
+    const d = new Date(generated_at);
+    $("#generated-at").textContent = `Actualizado ${d.toLocaleString()}`;
+  }
+  const dbSelect = $("#db-select");
+  dbSelect.innerHTML = "";
+  if (!databases || databases.length === 0) {
+    setStatus("No se encontraron databases en la página Monitor.", true);
+    return;
+  }
+  databases.forEach((db, i) => {
+    const opt = document.createElement("option");
+    opt.value = String(i);
+    opt.textContent = db.title || "Untitled";
+    dbSelect.appendChild(opt);
+  });
+  dbSelect.onchange = () => selectDb(Number(dbSelect.value));
+  selectDb(0);
+}
+
+function selectDb(index) {
+  state.currentDb = state.data.databases[index];
+  state.sortKey = null;
+  state.sortDir = 1;
+  state.search = "";
+  $("#search").value = "";
+  renderAll();
+}
+
+function isNumericField(db, key) {
+  const t = db.schema[key];
+  return t === "number" || t === "formula" || t === "rollup" || t === "unique_id";
+}
+
+function isCategoricalField(db, key) {
+  const t = db.schema[key];
+  return t === "select" || t === "status" || t === "multi_select";
+}
+
+function isDateField(db, key) {
+  const t = db.schema[key];
+  return t === "date" || t === "created_time" || t === "last_edited_time";
+}
+
+function getValue(row, key) {
+  const v = row[key];
+  if (v && typeof v === "object" && !Array.isArray(v) && "start" in v) {
+    return v.start;
+  }
+  return v;
+}
+
+function getNumeric(row, key) {
+  const v = getValue(row, key);
+  if (typeof v === "number") return v;
+  if (typeof v === "string" && v.trim() !== "") {
+    const n = Number(v);
+    if (!Number.isNaN(n)) return n;
+  }
+  return null;
+}
+
+function getDate(row, key) {
+  const v = getValue(row, key);
+  if (!v) return null;
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function formatCell(value, type) {
+  if (value === null || value === undefined || value === "") return "—";
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "—";
+    if (typeof value[0] === "object" && value[0] !== null && "url" in value[0]) {
+      return value
+        .map((f) => `<a href="${f.url}" target="_blank" rel="noreferrer">${escapeHtml(f.name || "file")}</a>`)
+        .join(", ");
+    }
+    return value.map((v) => `<span class="tag">${escapeHtml(String(v))}</span>`).join("");
+  }
+  if (typeof value === "object") {
+    if ("start" in value) {
+      const s = value.start ? new Date(value.start).toLocaleDateString() : "";
+      const e = value.end ? ` → ${new Date(value.end).toLocaleDateString()}` : "";
+      return `${s}${e}`;
+    }
+    return escapeHtml(JSON.stringify(value));
+  }
+  if (typeof value === "boolean") {
+    return value
+      ? `<span class="checkbox-true">✓</span>`
+      : `<span class="checkbox-false">·</span>`;
+  }
+  if (typeof value === "number") {
+    return value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+  if (type === "url" && typeof value === "string" && value.startsWith("http")) {
+    return `<a href="${value}" target="_blank" rel="noreferrer">${escapeHtml(value)}</a>`;
+  }
+  if (type === "email" && typeof value === "string") {
+    return `<a href="mailto:${value}">${escapeHtml(value)}</a>`;
+  }
+  if (typeof value === "string" && (type === "created_time" || type === "last_edited_time")) {
+    return new Date(value).toLocaleString();
+  }
+  return escapeHtml(String(value));
+}
+
+function escapeHtml(s) {
+  return s
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function renderAll() {
+  renderKpis();
+  renderChart1();
+  renderChart2();
+  renderTable();
+}
+
+function renderKpis() {
+  const db = state.currentDb;
+  const grid = $("#kpi-grid");
+  grid.innerHTML = "";
+
+  const rows = db.rows;
+  const cards = [];
+  cards.push(kpiCard("Filas", rows.length.toLocaleString(), db.title));
+
+  const numericKeys = Object.keys(db.schema).filter((k) => isNumericField(db, k));
+  for (const key of numericKeys.slice(0, 5)) {
+    let sum = 0;
+    let count = 0;
+    for (const r of rows) {
+      const n = getNumeric(r, key);
+      if (n !== null) {
+        sum += n;
+        count += 1;
+      }
+    }
+    const avg = count ? sum / count : 0;
+    cards.push(
+      kpiCard(
+        `Σ ${key}`,
+        sum.toLocaleString(undefined, { maximumFractionDigits: 2 }),
+        `prom ${avg.toLocaleString(undefined, { maximumFractionDigits: 2 })} (${count})`,
+      ),
+    );
+  }
+
+  if (numericKeys.length === 0) {
+    const catKeys = Object.keys(db.schema).filter((k) => isCategoricalField(db, k));
+    for (const key of catKeys.slice(0, 3)) {
+      const counts = new Map();
+      for (const r of rows) {
+        const v = r[key];
+        const items = Array.isArray(v) ? v : v ? [v] : [];
+        for (const it of items) counts.set(it, (counts.get(it) || 0) + 1);
+      }
+      const top = [...counts.entries()].sort((a, b) => b[1] - a[1])[0];
+      cards.push(kpiCard(key, top ? top[0] : "—", top ? `${top[1]} filas` : ""));
+    }
+  }
+
+  for (const c of cards) grid.appendChild(c);
+}
+
+function kpiCard(label, value, sub) {
+  const el = document.createElement("div");
+  el.className = "kpi";
+  el.innerHTML = `
+    <div class="kpi-label">${escapeHtml(label)}</div>
+    <div class="kpi-value">${escapeHtml(String(value))}</div>
+    ${sub ? `<div class="kpi-sub">${escapeHtml(sub)}</div>` : ""}
+  `;
+  return el;
+}
+
+function populateSelect(sel, options, defaultValue) {
+  sel.innerHTML = "";
+  for (const opt of options) {
+    const o = document.createElement("option");
+    o.value = opt;
+    o.textContent = opt;
+    sel.appendChild(o);
+  }
+  if (defaultValue && options.includes(defaultValue)) {
+    sel.value = defaultValue;
+  } else if (options.length > 0) {
+    sel.value = options[0];
+  }
+}
+
+function renderChart1() {
+  const db = state.currentDb;
+  const sel = $("#chart1-field");
+  const candidates = Object.keys(db.schema).filter(
+    (k) => isCategoricalField(db, k) || isNumericField(db, k),
+  );
+  if (candidates.length === 0) {
+    if (state.chart1) state.chart1.destroy();
+    $("#chart1-title").textContent = "Sin columnas para graficar";
+    return;
+  }
+  const current = sel.value && candidates.includes(sel.value) ? sel.value : candidates[0];
+  populateSelect(sel, candidates, current);
+  sel.onchange = () => drawChart1(sel.value);
+  drawChart1(current);
+}
+
+function drawChart1(key) {
+  const db = state.currentDb;
+  const counts = new Map();
+  const numeric = isNumericField(db, key);
+
+  if (numeric) {
+    const numericKeys = Object.keys(db.schema).filter(
+      (k) => isCategoricalField(db, k),
+    );
+    const groupBy = numericKeys[0];
+    if (groupBy) {
+      for (const r of db.rows) {
+        const v = r[groupBy];
+        const items = Array.isArray(v) ? v : v ? [v] : ["(sin valor)"];
+        const num = getNumeric(r, key) || 0;
+        for (const it of items) {
+          counts.set(it, (counts.get(it) || 0) + num);
+        }
+      }
+      $("#chart1-title").textContent = `Σ ${key} por ${groupBy}`;
+    } else {
+      const numericVals = db.rows.map((r) => getNumeric(r, key)).filter((v) => v !== null);
+      const bins = 8;
+      if (numericVals.length === 0) {
+        $("#chart1-title").textContent = `${key} — sin datos`;
+      } else {
+        const min = Math.min(...numericVals);
+        const max = Math.max(...numericVals);
+        const step = (max - min) / bins || 1;
+        for (let i = 0; i < bins; i++) {
+          const lo = min + i * step;
+          const hi = lo + step;
+          const label = `${lo.toFixed(1)}–${hi.toFixed(1)}`;
+          counts.set(label, numericVals.filter((v) => v >= lo && (i === bins - 1 ? v <= hi : v < hi)).length);
+        }
+        $("#chart1-title").textContent = `Distribución de ${key}`;
+      }
+    }
+  } else {
+    for (const r of db.rows) {
+      const v = r[key];
+      const items = Array.isArray(v) ? v : v != null && v !== "" ? [v] : ["(sin valor)"];
+      for (const it of items) counts.set(it, (counts.get(it) || 0) + 1);
+    }
+    $("#chart1-title").textContent = `Distribución de ${key}`;
+  }
+
+  const entries = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12);
+  const labels = entries.map((e) => String(e[0]));
+  const values = entries.map((e) => e[1]);
+  const colors = labels.map((_, i) => PALETTE[i % PALETTE.length]);
+
+  if (state.chart1) state.chart1.destroy();
+  const ctx = document.getElementById("chart1");
+  state.chart1 = new Chart(ctx, {
+    type: labels.length > 6 ? "bar" : "doughnut",
+    data: { labels, datasets: [{ data: values, backgroundColor: colors, borderWidth: 0 }] },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { position: labels.length > 6 ? "none" : "right", labels: { font: { size: 11 } } },
+      },
+      scales: labels.length > 6 ? { y: { beginAtZero: true } } : {},
+    },
+  });
+}
+
+function renderChart2() {
+  const db = state.currentDb;
+  const selDate = $("#chart2-date");
+  const selValue = $("#chart2-value");
+  const dateKeys = Object.keys(db.schema).filter((k) => isDateField(db, k));
+  const numKeys = Object.keys(db.schema).filter((k) => isNumericField(db, k));
+
+  if (dateKeys.length === 0 || numKeys.length === 0) {
+    if (state.chart2) state.chart2.destroy();
+    $("#chart2-title").textContent = "Necesita columna de fecha + número";
+    selDate.innerHTML = "";
+    selValue.innerHTML = "";
+    return;
+  }
+  populateSelect(selDate, dateKeys, selDate.value);
+  populateSelect(selValue, numKeys, selValue.value);
+  selDate.onchange = () => drawChart2(selDate.value, selValue.value);
+  selValue.onchange = () => drawChart2(selDate.value, selValue.value);
+  drawChart2(selDate.value, selValue.value);
+}
+
+function drawChart2(dateKey, valueKey) {
+  const db = state.currentDb;
+  const points = [];
+  for (const r of db.rows) {
+    const d = getDate(r, dateKey);
+    const v = getNumeric(r, valueKey);
+    if (d && v !== null) points.push({ x: d, y: v });
+  }
+  points.sort((a, b) => a.x - b.x);
+
+  $("#chart2-title").textContent = `${valueKey} vs ${dateKey}`;
+  if (state.chart2) state.chart2.destroy();
+  const ctx = document.getElementById("chart2");
+  state.chart2 = new Chart(ctx, {
+    type: "line",
+    data: {
+      labels: points.map((p) => p.x.toLocaleDateString()),
+      datasets: [
+        {
+          label: valueKey,
+          data: points.map((p) => p.y),
+          borderColor: "#0071e3",
+          backgroundColor: "rgba(0,113,227,0.12)",
+          fill: true,
+          tension: 0.3,
+          pointRadius: 3,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: { legend: { display: false } },
+      scales: { y: { beginAtZero: false } },
+    },
+  });
+}
+
+function renderTable() {
+  const db = state.currentDb;
+  const thead = $("#data-table thead");
+  const tbody = $("#data-table tbody");
+  const keys = Object.keys(db.schema);
+  const q = state.search.toLowerCase();
+
+  let rows = db.rows;
+  if (q) {
+    rows = rows.filter((r) =>
+      keys.some((k) => {
+        const v = r[k];
+        if (v == null) return false;
+        return JSON.stringify(v).toLowerCase().includes(q);
+      }),
+    );
+  }
+  if (state.sortKey) {
+    const k = state.sortKey;
+    const dir = state.sortDir;
+    rows = [...rows].sort((a, b) => {
+      const va = getValue(a, k);
+      const vb = getValue(b, k);
+      if (va == null && vb == null) return 0;
+      if (va == null) return 1;
+      if (vb == null) return -1;
+      if (typeof va === "number" && typeof vb === "number") return (va - vb) * dir;
+      return String(va).localeCompare(String(vb)) * dir;
+    });
+  }
+
+  thead.innerHTML =
+    "<tr>" +
+    keys
+      .map((k) => {
+        let cls = "";
+        if (state.sortKey === k) cls = state.sortDir === 1 ? "sorted-asc" : "sorted-desc";
+        return `<th data-key="${escapeHtml(k)}" class="${cls}">${escapeHtml(k)}</th>`;
+      })
+      .join("") +
+    "</tr>";
+
+  tbody.innerHTML = rows
+    .map(
+      (r) =>
+        "<tr>" +
+        keys
+          .map((k) => {
+            const numeric = isNumericField(db, k);
+            return `<td class="${numeric ? "num" : ""}">${formatCell(r[k], db.schema[k])}</td>`;
+          })
+          .join("") +
+        "</tr>",
+    )
+    .join("");
+
+  $("#row-count").textContent = `${rows.length} de ${db.rows.length} filas`;
+
+  thead.querySelectorAll("th").forEach((th) => {
+    th.onclick = () => {
+      const k = th.dataset.key;
+      if (state.sortKey === k) state.sortDir = -state.sortDir;
+      else {
+        state.sortKey = k;
+        state.sortDir = 1;
+      }
+      renderTable();
+    };
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  $("#repo-link").href = REPO_URL;
+  $("#refresh").onclick = loadData;
+  $("#search").addEventListener("input", (e) => {
+    state.search = e.target.value;
+    renderTable();
+  });
+  const tryLoad = () => {
+    if (typeof Chart === "undefined") {
+      setTimeout(tryLoad, 50);
+      return;
+    }
+    loadData();
+  };
+  tryLoad();
+});

--- a/docs/data.json
+++ b/docs/data.json
@@ -1,0 +1,5 @@
+{
+  "generated_at": null,
+  "page_id": null,
+  "databases": []
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Monitor · Notion Dashboard</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
+    <script src="./dashboard.js" type="module" defer></script>
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="topbar-left">
+        <h1>Monitor</h1>
+        <span id="generated-at" class="muted"></span>
+      </div>
+      <div class="topbar-right">
+        <label class="db-picker">
+          <span>Database</span>
+          <select id="db-select"></select>
+        </label>
+        <button id="refresh" class="btn" title="Recargar data.json">↻</button>
+      </div>
+    </header>
+
+    <main>
+      <section id="kpi-grid" class="kpi-grid"></section>
+
+      <section class="chart-row">
+        <article class="card chart-card">
+          <h2 id="chart1-title">Distribución</h2>
+          <div class="chart-controls">
+            <label>
+              Columna
+              <select id="chart1-field"></select>
+            </label>
+          </div>
+          <canvas id="chart1"></canvas>
+        </article>
+
+        <article class="card chart-card">
+          <h2 id="chart2-title">Tendencia</h2>
+          <div class="chart-controls">
+            <label>
+              Fecha
+              <select id="chart2-date"></select>
+            </label>
+            <label>
+              Valor
+              <select id="chart2-value"></select>
+            </label>
+          </div>
+          <canvas id="chart2"></canvas>
+        </article>
+      </section>
+
+      <section class="card table-card">
+        <header class="table-header">
+          <h2>Tabla</h2>
+          <div class="table-controls">
+            <input id="search" type="search" placeholder="Buscar…" />
+            <span id="row-count" class="muted"></span>
+          </div>
+        </header>
+        <div class="table-wrap">
+          <table id="data-table">
+            <thead></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="muted">
+      Datos sincronizados desde Notion via GitHub Actions.
+      <a id="repo-link" href="#" target="_blank" rel="noreferrer">Repo</a>
+    </footer>
+
+    <div id="status"></div>
+  </body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,368 @@
+:root {
+  --bg: #f5f5f7;
+  --card: #ffffff;
+  --text: #1d1d1f;
+  --muted: #86868b;
+  --border: #d2d2d7;
+  --accent: #0071e3;
+  --accent-soft: #e8f1fc;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.06);
+  --radius: 14px;
+  --radius-sm: 8px;
+  --c1: #8dbad6;
+  --c2: #9bc2e7;
+  --c3: #8ea9db;
+  --c4: #abb9d4;
+  --c5: #b9f5c4;
+  --c6: #fd9a9a;
+  --c7: #f8ccad;
+  --c8: #fef2cb;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #000000;
+    --card: #1c1c1e;
+    --text: #f5f5f7;
+    --muted: #98989d;
+    --border: #2c2c2e;
+    --accent: #2997ff;
+    --accent-soft: #112a44;
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI",
+    Roboto, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 32px;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: saturate(180%) blur(20px);
+}
+
+.topbar-left {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+}
+
+.topbar h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.btn {
+  background: var(--accent);
+  color: white;
+  border: 0;
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  font-size: 14px;
+  cursor: pointer;
+  font-weight: 500;
+  transition: opacity 0.15s ease;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+select,
+input[type="search"] {
+  background: var(--card);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.15s ease;
+}
+
+select:focus,
+input[type="search"]:focus {
+  border-color: var(--accent);
+}
+
+.db-picker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+main {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 24px 32px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.card {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 20px;
+}
+
+.card h2 {
+  margin: 0 0 12px;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.kpi {
+  background: var(--card);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.kpi-label {
+  font-size: 12px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+
+.kpi-value {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.kpi-sub {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.chart-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+@media (max-width: 900px) {
+  .chart-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.chart-card {
+  display: flex;
+  flex-direction: column;
+}
+
+.chart-card canvas {
+  max-height: 320px;
+}
+
+.chart-controls {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.chart-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.table-card {
+  padding: 0;
+  overflow: hidden;
+}
+
+.table-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.table-header h2 {
+  margin: 0;
+}
+
+.table-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.table-controls input[type="search"] {
+  width: 240px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+  max-height: 520px;
+  overflow-y: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+thead {
+  position: sticky;
+  top: 0;
+  background: var(--card);
+  z-index: 1;
+}
+
+th {
+  text-align: left;
+  font-weight: 600;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  white-space: nowrap;
+  user-select: none;
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+th.sorted-asc::after {
+  content: " ↑";
+  color: var(--accent);
+}
+
+th.sorted-desc::after {
+  content: " ↓";
+  color: var(--accent);
+}
+
+td {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+
+tbody tr:hover {
+  background: var(--accent-soft);
+}
+
+td.num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.tag {
+  display: inline-block;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  margin-right: 4px;
+}
+
+.checkbox-true,
+.checkbox-false {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  text-align: center;
+  line-height: 14px;
+  font-size: 11px;
+}
+.checkbox-true {
+  background: var(--accent);
+  color: white;
+}
+.checkbox-false {
+  background: var(--border);
+  color: var(--muted);
+}
+
+footer {
+  text-align: center;
+  padding: 24px;
+}
+
+#status {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  box-shadow: var(--shadow);
+  font-size: 13px;
+  max-width: 320px;
+  display: none;
+}
+
+#status.show {
+  display: block;
+}
+
+#status.error {
+  border-color: #ff453a;
+  color: #ff453a;
+}

--- a/scripts/fetch_notion.py
+++ b/scripts/fetch_notion.py
@@ -1,0 +1,226 @@
+"""Descarga todas las databases hijas de la pagina Monitor en Notion y escribe docs/data.json.
+
+Variables de entorno requeridas:
+  NOTION_TOKEN    - integration token (secret_xxx)
+  NOTION_PAGE_ID  - id de la pagina raiz "Monitor"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib import error, request
+
+NOTION_VERSION = "2022-06-28"
+API_BASE = "https://api.notion.com/v1"
+OUTPUT_PATH = Path(__file__).resolve().parent.parent / "docs" / "data.json"
+
+
+def _headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Notion-Version": NOTION_VERSION,
+        "Content-Type": "application/json",
+    }
+
+
+def _request(method: str, url: str, token: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    req = request.Request(url, data=data, method=method, headers=_headers(token))
+    for attempt in range(5):
+        try:
+            with request.urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except error.HTTPError as exc:
+            if exc.code == 429 and attempt < 4:
+                time.sleep(2 ** attempt)
+                continue
+            payload = exc.read().decode("utf-8", errors="replace")
+            raise SystemExit(f"Notion API {exc.code} on {url}: {payload}") from exc
+        except error.URLError as exc:
+            if attempt < 4:
+                time.sleep(2 ** attempt)
+                continue
+            raise SystemExit(f"Network error: {exc}") from exc
+    raise SystemExit("Exhausted retries")
+
+
+def list_child_databases(page_id: str, token: str) -> list[dict]:
+    """Recorre los bloques de una pagina y devuelve las child_database encontradas (recursivo)."""
+    databases: list[dict] = []
+    seen: set[str] = set()
+
+    def walk(block_id: str) -> None:
+        cursor: str | None = None
+        while True:
+            url = f"{API_BASE}/blocks/{block_id}/children?page_size=100"
+            if cursor:
+                url += f"&start_cursor={cursor}"
+            payload = _request("GET", url, token)
+            for block in payload.get("results", []):
+                btype = block.get("type")
+                bid = block.get("id")
+                if btype == "child_database" and bid not in seen:
+                    seen.add(bid)
+                    title = block.get("child_database", {}).get("title", "Untitled")
+                    databases.append({"id": bid, "title": title})
+                if block.get("has_children") and btype not in {"child_database", "unsupported"}:
+                    walk(bid)
+            if not payload.get("has_more"):
+                break
+            cursor = payload.get("next_cursor")
+
+    walk(page_id)
+    return databases
+
+
+def query_database(database_id: str, token: str) -> list[dict]:
+    rows: list[dict] = []
+    cursor: str | None = None
+    while True:
+        body: dict[str, Any] = {"page_size": 100}
+        if cursor:
+            body["start_cursor"] = cursor
+        payload = _request("POST", f"{API_BASE}/databases/{database_id}/query", token, body)
+        rows.extend(payload.get("results", []))
+        if not payload.get("has_more"):
+            break
+        cursor = payload.get("next_cursor")
+    return rows
+
+
+def get_database_meta(database_id: str, token: str) -> dict:
+    return _request("GET", f"{API_BASE}/databases/{database_id}", token)
+
+
+def _plain_text(rich: list[dict]) -> str:
+    return "".join(part.get("plain_text", "") for part in rich or [])
+
+
+def normalize_property(prop: dict) -> Any:
+    """Convierte una property de Notion a un valor JSON-friendly."""
+    ptype = prop.get("type")
+    if ptype is None:
+        return None
+    value = prop.get(ptype)
+
+    if ptype in {"title", "rich_text"}:
+        return _plain_text(value or [])
+    if ptype == "number":
+        return value
+    if ptype == "select":
+        return value.get("name") if value else None
+    if ptype == "multi_select":
+        return [item.get("name") for item in value or []]
+    if ptype == "status":
+        return value.get("name") if value else None
+    if ptype == "date":
+        if not value:
+            return None
+        return {"start": value.get("start"), "end": value.get("end")}
+    if ptype == "checkbox":
+        return bool(value)
+    if ptype == "url":
+        return value
+    if ptype == "email":
+        return value
+    if ptype == "phone_number":
+        return value
+    if ptype == "people":
+        return [p.get("name") or p.get("id") for p in value or []]
+    if ptype == "files":
+        out = []
+        for f in value or []:
+            name = f.get("name")
+            link = (f.get("file") or {}).get("url") or (f.get("external") or {}).get("url")
+            out.append({"name": name, "url": link})
+        return out
+    if ptype == "formula":
+        ftype = value.get("type") if value else None
+        return value.get(ftype) if ftype else None
+    if ptype == "rollup":
+        rtype = value.get("type") if value else None
+        if rtype == "array":
+            return [normalize_property({"type": item.get("type"), item.get("type"): item.get(item.get("type"))}) for item in value.get("array", [])]
+        return value.get(rtype) if rtype else None
+    if ptype == "relation":
+        return [r.get("id") for r in value or []]
+    if ptype == "created_time":
+        return value
+    if ptype == "created_by":
+        return (value or {}).get("name") or (value or {}).get("id")
+    if ptype == "last_edited_time":
+        return value
+    if ptype == "last_edited_by":
+        return (value or {}).get("name") or (value or {}).get("id")
+    if ptype == "unique_id":
+        prefix = (value or {}).get("prefix") or ""
+        number = (value or {}).get("number")
+        return f"{prefix}-{number}" if prefix else number
+    return value
+
+
+def serialize_row(page: dict) -> dict:
+    props = page.get("properties", {})
+    row: dict[str, Any] = {
+        "_id": page.get("id"),
+        "_url": page.get("url"),
+        "_created": page.get("created_time"),
+        "_edited": page.get("last_edited_time"),
+    }
+    for name, prop in props.items():
+        row[name] = normalize_property(prop)
+    return row
+
+
+def serialize_schema(db_meta: dict) -> dict:
+    """Devuelve {nombre: tipo} para que el frontend sepa como renderizar cada columna."""
+    schema: dict[str, str] = {}
+    for name, prop in (db_meta.get("properties") or {}).items():
+        schema[name] = prop.get("type", "unknown")
+    return schema
+
+
+def main() -> int:
+    token = os.environ.get("NOTION_TOKEN")
+    page_id = os.environ.get("NOTION_PAGE_ID")
+    if not token or not page_id:
+        print("ERROR: faltan NOTION_TOKEN o NOTION_PAGE_ID en el entorno", file=sys.stderr)
+        return 1
+
+    print(f"Buscando databases hijas en pagina {page_id}...")
+    databases = list_child_databases(page_id, token)
+    print(f"Encontradas {len(databases)} database(s)")
+
+    out_databases = []
+    for db in databases:
+        print(f"  -> {db['title']} ({db['id']})")
+        meta = get_database_meta(db["id"], token)
+        rows = query_database(db["id"], token)
+        title_text = _plain_text(meta.get("title", [])) or db["title"]
+        out_databases.append({
+            "id": db["id"],
+            "title": title_text,
+            "schema": serialize_schema(meta),
+            "rows": [serialize_row(r) for r in rows],
+        })
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "page_id": page_id,
+        "databases": out_databases,
+    }
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    print(f"Escrito {OUTPUT_PATH} ({sum(len(d['rows']) for d in out_databases)} filas en total)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a static dashboard hosted from /docs that reads data.json synced from Notion by a scheduled GitHub Action.

- scripts/fetch_notion.py: walks child databases of the Monitor page, normalizes every Notion property type to JSON and writes docs/data.json (stdlib-only, no third-party deps).
- .github/workflows/sync-notion.yml: runs every 15 min and on manual dispatch, executes the fetch script, commits data.json back to main if it changed.
- docs/: Apple-styled static dashboard with KPI cards, two Chart.js charts (categorical/distribution + time-series), and a sortable/searchable table. Auto-detects column types per database from the schema written by the fetch script.
- SETUP.md: step-by-step manual setup (create Notion integration, share Monitor page, add NOTION_TOKEN and NOTION_PAGE_ID secrets, enable workflow write permissions, enable Pages from /docs).

Token is read from the NOTION_TOKEN GitHub Actions secret; it is never written to the repo or shipped to the browser. data.json is public (anyone with the Pages URL can read it).