### PR TITLE
Improve mobile filter layout and income chart x-axis format

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -889,6 +889,14 @@ function renderIncomeMonthly(incomes, { from, to }) {
             maxRotation: 45,
             minRotation: 30,
             font: { size: isMobile() ? 9 : 11 },
+            callback: function (value) {
+              const label = this.getLabelForValue(value);
+              const [y, m] = label.split("-");
+              return new Date(+y, +m - 1, 1).toLocaleDateString("en-US", {
+                month: "short",
+                year: "numeric",
+              });
+            },
           },
         },
         y: { beginAtZero: true, ticks: { callback: (v) => fmtMoney(v) } },

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -734,16 +734,20 @@ footer {
     padding: 16px 16px;
   }
   .filter-row {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 12px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 8px;
   }
   .filter-row + .filter-row {
     margin-top: 14px;
     padding-top: 14px;
   }
   .filter-group {
-    width: 100%;
+    flex: 1 1 100%;
+  }
+  .filter-group.date-group {
+    flex: 1 1 calc(50% - 8px);
   }
   .filter-spacer {
     display: none;
@@ -754,7 +758,7 @@ footer {
     min-width: 0;
   }
   .filter-row > .btn-ghost {
-    align-self: stretch;
+    flex: 1 1 100%;
     width: 100%;
     justify-content: center;
     height: 36px;


### PR DESCRIPTION
## Summary

- **Filters mobile**: FROM and TO date inputs now sit side by side (50/50) instead of stacking full-width. Period stays full-width on top, Reset button spans full width below.
- **Income monthly x-axis**: Labels now show "May 2026" format instead of raw "2026-05".

https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_