### PR TITLE
Hide zero-value categories in expense evolution tooltip

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -760,6 +760,7 @@ function renderExpenseEvolution(expenses, { from, to }) {
         tooltip: {
           mode: "index",
           intersect: false,
+          filter: (item) => item.parsed.y > 0,
           callbacks: {
             title: isDaily
               ? (items) => {


### PR DESCRIPTION
Adds `filter: (item) => item.parsed.y > 0` to the expense evolution tooltip so only categories with actual spending show up on hover.

https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_