### PR TITLE
Fix expense evolution tooltip filter (use item.raw)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -760,7 +760,7 @@ function renderExpenseEvolution(expenses, { from, to }) {
         tooltip: {
           mode: "index",
           intersect: false,
-          filter: (item) => item.parsed.y > 0,
+          filter: (item) => Number(item.raw) > 0,
           callbacks: {
             title: isDaily
               ? (items) => {


### PR DESCRIPTION
Fixes the broken tooltip by switching from `item.parsed.y` to `item.raw` for the filter check. `parsed.y` is unreliable with `mode: "index"` in Chart.js v4 — `item.raw` directly reflects the value from the data array.

https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_