### PR TITLE
Fix chart freeze on zero-expense days (empty tooltip guard)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -764,6 +764,7 @@ function renderExpenseEvolution(expenses, { from, to }) {
           callbacks: {
             title: isDaily
               ? (items) => {
+                  if (!items.length) return "";
                   const d = new Date(items[0].label + "T00:00:00");
                   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
                 }


### PR DESCRIPTION
When all tooltip items are filtered out (hovering over a zero-expense day), Chart.js passes an empty array to the `title` callback. `items[0].label` on an empty array threw a TypeError that froze the chart. Added an `if (!items.length) return ""` guard.

https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_