### PR TITLE
Revert tooltip zero-filter changes (PRs #13, #14, #15)

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -760,11 +760,9 @@ function renderExpenseEvolution(expenses, { from, to }) {
         tooltip: {
           mode: "index",
           intersect: false,
-          filter: (item) => Number(item.raw) > 0,
           callbacks: {
             title: isDaily
               ? (items) => {
-                  if (!items.length) return "";
                   const d = new Date(items[0].label + "T00:00:00");
                   return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
                 }


### PR DESCRIPTION
Reverts PRs #13, #14, and #15 (tooltip zero-filter and its bug fixes). The filter caused the chart to freeze on zero-expense days. Restores original tooltip behavior from before those changes.

https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_