### PR TITLE
Larger tooltips across all charts

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1079,6 +1079,13 @@ function bootstrap() {
     if (Chart.defaults?.plugins) {
       Chart.defaults.plugins.datalabels = Chart.defaults.plugins.datalabels || {};
       Chart.defaults.plugins.datalabels.display = false;
+      // Larger, more readable tooltips across all charts.
+      Chart.defaults.plugins.tooltip.titleFont  = { size: 13, weight: "600" };
+      Chart.defaults.plugins.tooltip.bodyFont   = { size: 13 };
+      Chart.defaults.plugins.tooltip.padding    = 12;
+      Chart.defaults.plugins.tooltip.boxWidth   = 12;
+      Chart.defaults.plugins.tooltip.boxHeight  = 12;
+      Chart.defaults.plugins.tooltip.cornerRadius = 8;
     }
     loadData();
   };


### PR DESCRIPTION
Sets global Chart.js tooltip defaults once so all charts get larger, more readable tooltips: title 13px bold, body 13px, padding 12, color box 12×12, corner radius 8.

https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_