### PR TITLE
Increase tooltip size further

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -1080,12 +1080,12 @@ function bootstrap() {
       Chart.defaults.plugins.datalabels = Chart.defaults.plugins.datalabels || {};
       Chart.defaults.plugins.datalabels.display = false;
       // Larger, more readable tooltips across all charts.
-      Chart.defaults.plugins.tooltip.titleFont  = { size: 13, weight: "600" };
-      Chart.defaults.plugins.tooltip.bodyFont   = { size: 13 };
-      Chart.defaults.plugins.tooltip.padding    = 12;
-      Chart.defaults.plugins.tooltip.boxWidth   = 12;
-      Chart.defaults.plugins.tooltip.boxHeight  = 12;
-      Chart.defaults.plugins.tooltip.cornerRadius = 8;
+      Chart.defaults.plugins.tooltip.titleFont  = { size: 16, weight: "600" };
+      Chart.defaults.plugins.tooltip.bodyFont   = { size: 15 };
+      Chart.defaults.plugins.tooltip.padding    = 16;
+      Chart.defaults.plugins.tooltip.boxWidth   = 14;
+      Chart.defaults.plugins.tooltip.boxHeight  = 14;
+      Chart.defaults.plugins.tooltip.cornerRadius = 10;
     }
     loadData();
   };


### PR DESCRIPTION
Increases tooltip size further: title 16px bold, body 15px, padding 16, color box 14×14, corner radius 10.

https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_