### PR TITLE
Reduce tooltip size; increase chart and page font sizes

### DIFF
--- a/docs/dashboard.js
+++ b/docs/dashboard.js
@@ -585,7 +585,7 @@ function renderExpenseDonut(expenses) {
             boxWidth: 8,
             boxHeight: 8,
             padding: isMobile() ? 8 : 10,
-            font: { size: isMobile() ? 11 : 12 },
+            font: { size: isMobile() ? 12 : 14 },
           },
         },
         tooltip: {
@@ -600,7 +600,7 @@ function renderExpenseDonut(expenses) {
             return total > 0 && (v / total) * 100 >= 4;
           },
           color: DONUT_LABEL_COLOR,
-          font: { weight: "400", size: 11 },
+          font: { weight: "400", size: 13 },
           formatter: (v) => `${((v / total) * 100).toFixed(1)}%`,
           anchor: "center",
           align: "center",
@@ -649,18 +649,18 @@ function renderExpenseSumBars(expenses) {
           align: "top",
           offset: 4,
           color: BAR_LABEL_COLOR,
-          font: { size: 10, weight: "400" },
+          font: { size: 12, weight: "400" },
           formatter: (v) => fmtMoney(v),
         },
       },
       scales: {
         x: {
           grid: { display: false },
-          ticks: { font: { size: isMobile() ? 9 : 11 }, maxRotation: 45, minRotation: 30 },
+          ticks: { font: { size: isMobile() ? 11 : 13 }, maxRotation: 45, minRotation: 30 },
         },
         y: {
           beginAtZero: true,
-          ticks: { callback: (v) => fmtMoney(v), font: { size: isMobile() ? 9 : 11 } },
+          ticks: { callback: (v) => fmtMoney(v), font: { size: isMobile() ? 11 : 13 } },
         },
       },
     },
@@ -754,7 +754,7 @@ function renderExpenseEvolution(expenses, { from, to }) {
             boxWidth: 5,
             boxHeight: 5,
             padding: 10,
-            font: { size: isMobile() ? 9 : 11 },
+            font: { size: isMobile() ? 11 : 13 },
           },
         },
         tooltip: {
@@ -779,13 +779,13 @@ function renderExpenseEvolution(expenses, { from, to }) {
             maxTicksLimit: isMobile() ? 8 : (isDaily ? 16 : 20),
             maxRotation: isDaily ? 0 : 45,
             minRotation: 0,
-            font: { size: isMobile() ? 9 : 11 },
+            font: { size: isMobile() ? 11 : 13 },
             callback: xTickCallback,
           },
         },
         y: {
           beginAtZero: true,
-          ticks: { callback: (v) => fmtMoney(v), font: { size: isMobile() ? 9 : 11 } },
+          ticks: { callback: (v) => fmtMoney(v), font: { size: isMobile() ? 11 : 13 } },
         },
       },
     },
@@ -833,7 +833,7 @@ function renderIncomeYearly() {
           align: "top",
           offset: 4,
           color: BAR_LABEL_COLOR,
-          font: { size: 10, weight: "400" },
+          font: { size: 12, weight: "400" },
           formatter: (v) => fmtMoney(v),
         },
       },
@@ -900,7 +900,7 @@ function renderIncomeMonthly(incomes, { from, to }) {
             maxTicksLimit: isMobile() ? 6 : 20,
             maxRotation: 45,
             minRotation: 30,
-            font: { size: isMobile() ? 9 : 11 },
+            font: { size: isMobile() ? 11 : 13 },
             callback: function (value) {
               const label = this.getLabelForValue(value);
               const [y, m] = label.split("-");
@@ -1079,13 +1079,12 @@ function bootstrap() {
     if (Chart.defaults?.plugins) {
       Chart.defaults.plugins.datalabels = Chart.defaults.plugins.datalabels || {};
       Chart.defaults.plugins.datalabels.display = false;
-      // Larger, more readable tooltips across all charts.
-      Chart.defaults.plugins.tooltip.titleFont  = { size: 16, weight: "600" };
-      Chart.defaults.plugins.tooltip.bodyFont   = { size: 15 };
-      Chart.defaults.plugins.tooltip.padding    = 16;
-      Chart.defaults.plugins.tooltip.boxWidth   = 14;
-      Chart.defaults.plugins.tooltip.boxHeight  = 14;
-      Chart.defaults.plugins.tooltip.cornerRadius = 10;
+      Chart.defaults.plugins.tooltip.titleFont  = { size: 14, weight: "600" };
+      Chart.defaults.plugins.tooltip.bodyFont   = { size: 13 };
+      Chart.defaults.plugins.tooltip.padding    = 12;
+      Chart.defaults.plugins.tooltip.boxWidth   = 12;
+      Chart.defaults.plugins.tooltip.boxHeight  = 12;
+      Chart.defaults.plugins.tooltip.cornerRadius = 8;
     }
     loadData();
   };

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -46,7 +46,7 @@ body {
   color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "Segoe UI",
     Roboto, sans-serif;
-  font-size: 14px;
+  font-size: 15px;
   line-height: 1.5;
   -webkit-text-size-adjust: 100%;
 }
@@ -374,7 +374,7 @@ body > section.filters {
 .kpi.fixed { border-left-color: var(--cat-fixed); }
 
 .kpi-label {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -383,7 +383,7 @@ body > section.filters {
 
 .kpi-value {
   color: var(--text-soft);
-  font-size: clamp(15px, 1.6vw, 22px);
+  font-size: clamp(16px, 1.7vw, 24px);
   font-weight: 600;
   letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;
@@ -393,7 +393,7 @@ body > section.filters {
 .kpi-value.negative { color: var(--red); }
 
 .kpi-sub {
-  font-size: 11px;
+  font-size: 12px;
   color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
@@ -414,13 +414,13 @@ body > section.filters {
 
 .section-head h2 {
   margin: 0;
-  font-size: 17px;
+  font-size: 19px;
   font-weight: 600;
   letter-spacing: -0.01em;
 }
 
 .section-period {
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 400;
   color: var(--muted);
   letter-spacing: 0;
@@ -451,7 +451,7 @@ body > section.filters {
 
 .chart-box h3 {
   margin: 0 0 12px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -491,7 +491,7 @@ body > section.filters {
 table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 thead {
@@ -510,7 +510,7 @@ th {
   white-space: nowrap;
   user-select: none;
   color: var(--muted);
-  font-size: 11px;
+  font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }


### PR DESCRIPTION
- Tooltip slightly smaller: title 14px, body 13px, padding 12
- Chart axis ticks: 13px desktop / 11px mobile (up from 11/9)
- Chart legends: 14px desktop / 12px mobile
- Chart data labels: 12–13px (up from 10–11px)
- Page base font: 15px (up from 14px)
- Tables: 14px, table headers: 12px
- KPI labels: 12px, KPI values slightly larger
- Section headings: 19px, chart subtitles: 13px

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_