### PR TITLE
Make workout page responsive for laptop and mobile

### DIFF
--- a/docs/workout/index.html
+++ b/docs/workout/index.html
@@ -2,7 +2,8 @@
 <html lang="es">
 <head>
 <meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="theme-color" content="#15161B">
 <title>Mi Rutina — Hipertrofia + Movilidad</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -16,16 +17,23 @@
     --disp:'Oswald',system-ui,sans-serif;
     --body:'Inter',system-ui,sans-serif;
     --mono:'JetBrains Mono',ui-monospace,monospace;
+    --pad:clamp(14px,4vw,28px);
   }
   *{box-sizing:border-box;margin:0;padding:0}
   html{-webkit-text-size-adjust:100%}
   body{
-    background:var(--bg); color:var(--txt);
+    background:
+      radial-gradient(110% 60% at 50% -10%, color-mix(in srgb,var(--accent) 7%, transparent), transparent 60%),
+      var(--bg);
+    background-attachment:fixed;
+    color:var(--txt);
     font-family:var(--body); line-height:1.5;
     -webkit-font-smoothing:antialiased;
-    padding:26px 16px 56px;
+    padding:clamp(20px,5vw,40px) var(--pad)
+            calc(56px + env(safe-area-inset-bottom));
+    min-height:100vh;
   }
-  .wrap{max-width:780px;margin:0 auto}
+  .wrap{max-width:960px;margin:0 auto}
 
   /* ---------- header ---------- */
   .eyebrow{
@@ -36,7 +44,7 @@
   .eyebrow::before{content:"";width:26px;height:1px;background:var(--line)}
   h1{
     font-family:var(--disp); font-weight:700; text-transform:uppercase;
-    font-size:clamp(38px,11vw,66px); line-height:.92; letter-spacing:.005em;
+    font-size:clamp(38px,10vw,72px); line-height:.92; letter-spacing:.005em;
   }
   h1 span{display:block;color:var(--accent);transition:color .4s ease}
   .meta{
@@ -54,15 +62,17 @@
     font-family:var(--mono); font-size:10.5px; letter-spacing:.22em;
     text-transform:uppercase; color:var(--faint); margin:30px 0 11px;
   }
+  /* Mobile: horizontal swipe strip */
   .week{
-    display:flex; gap:8px; overflow-x:auto; padding-bottom:8px;
+    display:flex; gap:8px; overflow-x:auto;
+    padding-bottom:8px; margin:0 calc(var(--pad) * -1); padding-inline:var(--pad);
     scroll-snap-type:x mandatory; -webkit-overflow-scrolling:touch;
   }
   .week::-webkit-scrollbar{height:5px}
   .week::-webkit-scrollbar-thumb{background:var(--line);border-radius:10px}
   .day-btn{
     scroll-snap-align:start; flex:0 0 auto; cursor:pointer;
-    min-width:92px; text-align:left; color:var(--muted);
+    min-width:96px; text-align:left; color:var(--muted);
     background:var(--bg2); border:1px solid var(--line);
     border-radius:13px; padding:11px 12px 12px; overflow:hidden;
     position:relative; transition:border-color .2s, background .2s, color .2s, transform .15s;
@@ -78,6 +88,7 @@
     font-size:17px; line-height:1.05; margin-top:5px; letter-spacing:.01em;
   }
   .day-btn:hover{transform:translateY(-2px);border-color:var(--dc)}
+  .day-btn:active{transform:translateY(0) scale(.98)}
   .day-btn[aria-selected="true"]{
     color:var(--txt);
     background:color-mix(in srgb,var(--dc) 15%, var(--bg2));
@@ -86,13 +97,25 @@
   .day-btn[aria-selected="true"]::before{opacity:1;height:4px}
   .day-btn[aria-selected="true"] .dfoc{color:var(--dc)}
 
+  /* Desktop / tablet: all 7 days visible as a grid, no scroll needed */
+  @media(min-width:720px){
+    .week{
+      display:grid; grid-template-columns:repeat(7,1fr);
+      overflow:visible; margin:0; padding:0;
+    }
+    .day-btn{min-width:0}
+    .swipe-hint{display:none}
+  }
+
   /* ---------- detail card ---------- */
   .card{
     margin-top:16px; background:var(--bg2); border:1px solid var(--line);
     border-radius:20px; overflow:hidden;
+    box-shadow:0 18px 50px -28px rgba(0,0,0,.7);
   }
   .card-top{
-    padding:22px 22px 20px; border-bottom:1px solid var(--line);
+    padding:clamp(20px,4vw,28px) clamp(20px,4vw,30px) clamp(18px,3.5vw,24px);
+    border-bottom:1px solid var(--line);
     background:
       radial-gradient(120% 130% at 100% 0%, color-mix(in srgb,var(--accent) 13%, transparent), transparent 55%),
       var(--bg2);
@@ -106,12 +129,12 @@
   }
   .focus{
     font-family:var(--disp); font-weight:700; text-transform:uppercase;
-    font-size:clamp(30px,8vw,46px); line-height:.95; margin-top:12px;
+    font-size:clamp(30px,7vw,52px); line-height:.95; margin-top:12px;
     color:var(--accent); transition:color .4s ease;
   }
   .focus-sub{
     font-family:var(--disp); font-weight:500; text-transform:uppercase;
-    letter-spacing:.05em; font-size:15px; color:var(--muted); margin-top:5px;
+    letter-spacing:.05em; font-size:clamp(14px,2.4vw,17px); color:var(--muted); margin-top:5px;
   }
   .chips{display:flex;flex-wrap:wrap;gap:7px;margin-top:16px}
   .chip{
@@ -125,7 +148,7 @@
     display:grid; grid-template-columns:1fr; gap:0;
   }
   @media(min-width:680px){
-    .card-body{grid-template-columns:264px 1fr}
+    .card-body{grid-template-columns:minmax(240px,300px) 1fr}
   }
 
   /* ---------- muscle map ---------- */
@@ -152,7 +175,7 @@
   }
   .legend span{font-family:var(--mono);font-size:10px;color:var(--muted);letter-spacing:.04em}
   .figs{display:flex;gap:6px;justify-content:center}
-  .fig-col{flex:1;max-width:140px;text-align:center}
+  .fig-col{flex:1;max-width:150px;text-align:center}
   .figure{width:100%;height:auto;display:block}
   .fig-label{
     font-family:var(--mono);font-size:9.5px;letter-spacing:.18em;
@@ -176,7 +199,7 @@
   .ex-row + .ex-row{border-top:1px solid var(--line)}
   .ex-row:hover{background:var(--bg3)}
   .ex-n{
-    flex:0 0 auto;width:24px;height:24px;border-radius:7px;
+    flex:0 0 auto;width:26px;height:26px;border-radius:7px;
     display:grid;place-items:center;
     font-family:var(--mono);font-size:11px;font-weight:700;
     color:var(--accent);
@@ -184,7 +207,7 @@
     border:1px solid color-mix(in srgb,var(--accent) 30%, var(--line));
     transition:color .4s, background .4s, border-color .4s;
   }
-  .ex-name{flex:1;font-size:14.5px;font-weight:500;color:var(--txt)}
+  .ex-name{flex:1;min-width:0;font-size:clamp(14px,2.6vw,15.5px);font-weight:500;color:var(--txt)}
   .ex-name small{display:block;font-size:12px;color:var(--faint);font-weight:400;margin-top:1px}
   .ex-vol{
     flex:0 0 auto;font-family:var(--mono);font-weight:700;font-size:13px;
@@ -206,8 +229,9 @@
   @media(min-width:680px){.grid4{grid-template-columns:repeat(4,1fr)}}
   .pcard{
     background:var(--bg2);border:1px solid var(--line);border-radius:15px;
-    padding:16px 15px;
+    padding:16px 15px; transition:border-color .2s, transform .15s;
   }
+  .pcard:hover{border-color:color-mix(in srgb,var(--accent) 35%, var(--line));transform:translateY(-2px)}
   .pcard .pk{
     font-family:var(--mono);font-size:18px;font-weight:700;color:var(--accent);
     letter-spacing:.02em;
@@ -245,7 +269,7 @@
     </div>
   </header>
 
-  <div class="week-label">Elige el día · desliza →</div>
+  <div class="week-label">Elige el día<span class="swipe-hint"> · desliza →</span></div>
   <div class="week" id="week" role="tablist" aria-label="Días de la semana"></div>
 
   <section class="card" id="card" data-type="push" aria-live="polite">


### PR DESCRIPTION
Improves the `/monitor/workout/` page so it looks good on both laptop browsers and phones.

**Desktop / tablet (≥720px):**
- All 7 days are shown at once in a full-width 7-column grid — no more horizontal scrolling
- The "desliza →" swipe hint is hidden (not needed)
- Wider 960px container so the layout fills the screen instead of sitting in a narrow column

**Mobile:**
- Keeps the swipeable day strip, now bleeding edge-to-edge for a more native feel
- Fluid `clamp()`-based typography and padding so headings/spacing scale down cleanly

**Polish (both):**
- Subtle background glow + card shadow
- Hover/active states on day buttons and principle cards
- `safe-area-inset` padding and `theme-color` for installed/standalone use

Verified with headless screenshots at 1280px and 390px widths.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_