### PR TITLE
Demo how to do each exercise on the body figure

### DIFF
--- a/docs/workout/index.html
+++ b/docs/workout/index.html
@@ -189,15 +189,59 @@
   }
   .m.soft{fill:color-mix(in srgb,var(--accent) 38%, var(--muscle))}
 
+  /* ---------- exercise demo animations ---------- */
+  @keyframes demoBounce{
+    0%,100%{ transform:translateY(0) }
+    50%{ transform:translateY(-5px) }
+  }
+  @keyframes demoRotate{
+    0%,100%{ transform:rotate(0deg) }
+    50%{ transform:rotate(10deg) }
+  }
+  @keyframes demoPulse{
+    0%,100%{ transform:scale(1); opacity:1 }
+    50%{ transform:scale(1.07); opacity:.7 }
+  }
+  .m.demo-bounce{
+    transform-box:fill-box; transform-origin:center;
+    animation:demoBounce 1.1s ease-in-out infinite;
+  }
+  .m.demo-rotate{
+    transform-box:fill-box; transform-origin:top center;
+    animation:demoRotate 1.1s ease-in-out infinite;
+  }
+  .m.demo-pulse{
+    transform-box:fill-box; transform-origin:center;
+    animation:demoPulse 1.6s ease-in-out infinite;
+  }
+
+  /* ---------- move info panel ---------- */
+  .move-info{
+    margin-top:14px; padding-top:14px; border-top:1px solid var(--line);
+    min-height:62px;
+  }
+  .move-info-empty{
+    font-family:var(--mono); font-size:11px; letter-spacing:.06em;
+    color:var(--faint); text-align:center; padding:8px 4px;
+  }
+  .move-info-name{
+    font-family:var(--disp); font-weight:600; text-transform:uppercase;
+    letter-spacing:.04em; font-size:14px; color:var(--accent); margin-bottom:5px;
+  }
+  .move-info-cue{
+    font-size:12.5px; color:var(--muted); line-height:1.55;
+  }
+
   /* ---------- exercises ---------- */
   .ex{padding:8px 8px 10px}
   .ex-row{
     display:flex;align-items:center;gap:13px;
-    padding:13px 14px;border-radius:12px;
-    transition:background .15s;
+    padding:13px 14px;border-radius:12px;cursor:pointer;
+    transition:background .15s; -webkit-tap-highlight-color:transparent;
   }
   .ex-row + .ex-row{border-top:1px solid var(--line)}
   .ex-row:hover{background:var(--bg3)}
+  .ex-row.active{background:color-mix(in srgb,var(--accent) 13%, transparent)}
   .ex-n{
     flex:0 0 auto;width:26px;height:26px;border-radius:7px;
     display:grid;place-items:center;
@@ -206,6 +250,9 @@
     background:color-mix(in srgb,var(--accent) 14%, transparent);
     border:1px solid color-mix(in srgb,var(--accent) 30%, var(--line));
     transition:color .4s, background .4s, border-color .4s;
+  }
+  .ex-row.active .ex-n{
+    color:var(--bg2); background:var(--accent); border-color:var(--accent);
   }
   .ex-name{flex:1;min-width:0;font-size:clamp(14px,2.6vw,15.5px);font-weight:500;color:var(--txt)}
   .ex-name small{display:block;font-size:12px;color:var(--faint);font-weight:400;margin-top:1px}
@@ -338,6 +385,9 @@
             <div class="fig-label">Espalda</div>
           </div>
         </div>
+        <div class="move-info" id="move-info">
+          <div class="move-info-empty">Toca un ejercicio para ver cómo hacerlo →</div>
+        </div>
       </div>
       <div class="ex" id="d-ex"></div>
     </div>
@@ -376,12 +426,18 @@ const PLANS = {
     chips:['<b>Calentar</b> 5–10′','<b>Fuerza</b> ~40′','<b>Estirar</b> 10′'],
     muscles:['chest','frontdelt','triceps'],
     ex:[
-      {name:'Press de banca', vol:'4×8-10'},
-      {name:'Press inclinado con mancuernas', vol:'3×10-12'},
-      {name:'Press militar de hombro', vol:'3×8-10'},
-      {name:'Elevaciones laterales', vol:'3×12-15'},
-      {name:'Fondos o press francés', sub:'tríceps', vol:'3×10-12'},
-      {name:'Extensión de tríceps en polea', vol:'3×12-15'},
+      {name:'Press de banca', vol:'4×8-10', target:['chest','frontdelt','triceps'], move:'bounce',
+        cue:'Acostado en el banco, baja la barra hasta el pecho con control y empuja hacia arriba extendiendo los brazos.'},
+      {name:'Press inclinado con mancuernas', vol:'3×10-12', target:['chest','frontdelt'], move:'bounce',
+        cue:'En banco inclinado ~30°, empuja las mancuernas hacia arriba y ligeramente hacia adentro, baja hasta sentir el estiramiento en el pecho.'},
+      {name:'Press militar de hombro', vol:'3×8-10', target:['frontdelt','triceps'], move:'bounce',
+        cue:'De pie o sentado, empuja el peso por encima de la cabeza hasta extender los brazos, baja controlado a la altura de los hombros.'},
+      {name:'Elevaciones laterales', vol:'3×12-15', target:['frontdelt','reardelt'], move:'bounce',
+        cue:'Con los brazos casi rectos a los costados, levántalos hasta la altura de los hombros sin balancear el torso, baja controlado.'},
+      {name:'Fondos o press francés', sub:'tríceps', vol:'3×10-12', target:['triceps'], move:'bounce',
+        cue:'Extiende los brazos empujando el peso hacia arriba, flexiona el codo de forma controlada al bajar.'},
+      {name:'Extensión de tríceps en polea', vol:'3×12-15', target:['triceps'], move:'bounce',
+        cue:'Codos pegados al cuerpo, extiende los antebrazos hacia abajo hasta estirar por completo, vuelve sin soltar la tensión.'},
     ]
   },
   pull:{
@@ -389,12 +445,18 @@ const PLANS = {
     chips:['<b>Calentar</b> 5–10′','<b>Fuerza</b> ~40′','<b>Estirar</b> 10′'],
     muscles:['back','traps','reardelt','biceps','forearms'],
     ex:[
-      {name:'Dominadas o jalón al pecho', vol:'4×8-10'},
-      {name:'Remo con barra', vol:'4×8-10'},
-      {name:'Remo con mancuerna', vol:'3×10-12'},
-      {name:'Face pulls', sub:'hombro posterior', vol:'3×12-15'},
-      {name:'Curl de bíceps con barra', vol:'3×10-12'},
-      {name:'Curl martillo', vol:'3×12'},
+      {name:'Dominadas o jalón al pecho', vol:'4×8-10', target:['back','biceps'], move:'bounce',
+        cue:'Desde los brazos extendidos, jala tu cuerpo (o la barra) hacia arriba hasta que la barbilla pase la barra, baja controlado.'},
+      {name:'Remo con barra', vol:'4×8-10', target:['back','reardelt'], move:'bounce',
+        cue:'Inclina el torso manteniendo la espalda recta, jala la barra hacia el abdomen apretando los omóplatos, baja controlado.'},
+      {name:'Remo con mancuerna', vol:'3×10-12', target:['back','biceps'], move:'bounce',
+        cue:'Apoya una rodilla y mano en el banco, jala la mancuerna hacia la cadera manteniendo el codo cerca del cuerpo.'},
+      {name:'Face pulls', sub:'hombro posterior', vol:'3×12-15', target:['reardelt','traps'], move:'bounce',
+        cue:'Jala la cuerda hacia tu cara separando las manos, codos altos, aprieta los omóplatos al final del movimiento.'},
+      {name:'Curl de bíceps con barra', vol:'3×10-12', target:['biceps'], move:'rotate',
+        cue:'Codos fijos al costado del cuerpo, flexiona los antebrazos llevando la barra hacia los hombros, baja controlado.'},
+      {name:'Curl martillo', vol:'3×12', target:['biceps','forearms'], move:'rotate',
+        cue:'Con agarre neutro (palmas enfrentadas), flexiona los antebrazos hacia los hombros sin mover los codos.'},
     ]
   },
   legs:{
@@ -402,12 +464,18 @@ const PLANS = {
     chips:['<b>Calentar</b> 5–10′','<b>Fuerza</b> ~40′','<b>Estirar</b> 10′'],
     muscles:['quads','hamstrings','glutes','calves'],
     ex:[
-      {name:'Sentadilla', vol:'4×8-10'},
-      {name:'Prensa', vol:'3×10-12'},
-      {name:'Peso muerto rumano', sub:'femoral', vol:'3×10-12'},
-      {name:'Zancadas', vol:'3×12 / pierna'},
-      {name:'Extensión de cuádriceps', vol:'3×12-15'},
-      {name:'Elevación de gemelos', vol:'4×15-20'},
+      {name:'Sentadilla', vol:'4×8-10', target:['quads','glutes'], move:'bounce',
+        cue:'Baja flexionando rodillas y caderas con la espalda recta, hasta que los muslos queden paralelos al piso, empuja para subir.'},
+      {name:'Prensa', vol:'3×10-12', target:['quads','glutes'], move:'bounce',
+        cue:'Empuja la plataforma extendiendo las piernas, controla la bajada doblando las rodillas hacia el pecho.'},
+      {name:'Peso muerto rumano', sub:'femoral', vol:'3×10-12', target:['hamstrings','glutes','lowerback'], move:'bounce',
+        cue:'Con piernas casi rectas, lleva la cadera hacia atrás bajando el peso pegado a las piernas hasta sentir el estiramiento en isquios, vuelve apretando el glúteo.'},
+      {name:'Zancadas', vol:'3×12 / pierna', target:['quads','glutes','hamstrings'], move:'bounce',
+        cue:'Da un paso largo al frente y baja la rodilla trasera hacia el piso, empuja con la pierna delantera para volver.'},
+      {name:'Extensión de cuádriceps', vol:'3×12-15', target:['quads'], move:'bounce',
+        cue:'Sentado, extiende las rodillas levantando el peso hasta que las piernas queden rectas, baja controlado.'},
+      {name:'Elevación de gemelos', vol:'4×15-20', target:['calves'], move:'bounce',
+        cue:'Sube los talones lo más alto posible apoyándote en la punta de los pies, mantén un segundo arriba y baja controlado.'},
     ]
   },
   mob:{
@@ -415,13 +483,20 @@ const PLANS = {
     chips:['<b>Recuperación</b> activa','~40–50′','<b>Cardio</b> opcional 20′'],
     muscles:['all'],
     ex:[
-      {name:'Movilidad de cadera 90/90', vol:'2×60s'},
-      {name:'Gato–camello', sub:'columna', vol:'8-10'},
-      {name:'Estiramiento de isquios', vol:'2×30s'},
-      {name:'Apertura de pecho en pared', vol:'2×30s'},
-      {name:'Pass-through de hombros', sub:'con palo o banda', vol:'2×10'},
-      {name:'Sentadilla profunda sostenida', vol:'2×45s'},
-      {name:'Cardio suave', sub:'opcional', vol:'20′'},
+      {name:'Movilidad de cadera 90/90', vol:'2×60s', target:['glutes','hamstrings'], move:'rotate',
+        cue:'Sentado con ambas piernas dobladas a 90°, rota las caderas de un lado al otro manteniendo la espalda recta.'},
+      {name:'Gato–camello', sub:'columna', vol:'8-10', target:['lowerback','traps','abs'], move:'bounce',
+        cue:'En cuatro apoyos, arquea la espalda hacia arriba (gato) y luego hacia abajo dejando caer el abdomen (camello), de forma lenta.'},
+      {name:'Estiramiento de isquios', vol:'2×30s', target:['hamstrings'], move:'pulse',
+        cue:'Con una pierna extendida, inclina el torso hacia adelante manteniendo la espalda recta hasta sentir el estiramiento detrás del muslo.'},
+      {name:'Apertura de pecho en pared', vol:'2×30s', target:['chest','frontdelt'], move:'pulse',
+        cue:'Apoya el antebrazo en la pared con el codo a 90° y gira el cuerpo hacia el lado contrario para abrir el pecho y el hombro.'},
+      {name:'Pass-through de hombros', sub:'con palo o banda', vol:'2×10', target:['frontdelt','reardelt'], move:'rotate',
+        cue:'Sujeta una banda o palo con los brazos extendidos y llévalo desde el frente hasta atrás de la cabeza, manteniendo los brazos rectos.'},
+      {name:'Sentadilla profunda sostenida', vol:'2×45s', target:['quads','glutes'], move:'pulse',
+        cue:'Baja a la posición más profunda de sentadilla que puedas y mantente ahí, relajando caderas y zona lumbar.'},
+      {name:'Cardio suave', sub:'opcional', vol:'20′', target:['calves','quads'], move:'bounce',
+        cue:'Mantén un ritmo ligero y constante (caminar rápido, bici o elíptica) para activar la circulación.'},
     ]
   }
 };
@@ -429,6 +504,8 @@ const PLANS = {
 const card  = document.getElementById('card');
 const weekEl = document.getElementById('week');
 const figMs  = document.querySelectorAll('.m');
+const moveInfo = document.getElementById('move-info');
+const DEMO_CLASSES = ['demo-bounce','demo-rotate','demo-pulse'];
 
 // build week strip
 WEEK.forEach((d,i)=>{
@@ -440,6 +517,36 @@ WEEK.forEach((d,i)=>{
   weekEl.appendChild(b);
 });
 const btns=weekEl.querySelectorAll('.day-btn');
+
+// highlight every muscle worked on this day (default view)
+function showDayMuscles(p){
+  const all = p.muscles.includes('all');
+  figMs.forEach(m=>{
+    m.classList.remove('on','soft',...DEMO_CLASSES);
+    if(all){ m.classList.add('soft'); }
+    else if(p.muscles.includes(m.dataset.k)){ m.classList.add('on'); }
+  });
+}
+
+// highlight + animate only the muscles targeted by one exercise
+function showExerciseDemo(p, ex){
+  const demoClass = `demo-${ex.move || 'bounce'}`;
+  figMs.forEach(m=>{
+    m.classList.remove('on','soft',...DEMO_CLASSES);
+    if(ex.target && ex.target.includes(m.dataset.k)){
+      m.classList.add('on', demoClass);
+    } else if(p.muscles.includes(m.dataset.k) || p.muscles.includes('all')){
+      m.classList.add('soft');
+    }
+  });
+  moveInfo.innerHTML = `
+    <div class="move-info-name">${ex.name}</div>
+    <div class="move-info-cue">${ex.cue || ''}</div>`;
+}
+
+function hideMoveInfo(){
+  moveInfo.innerHTML = `<div class="move-info-empty">Toca un ejercicio para ver cómo hacerlo →</div>`;
+}
 
 function select(i){
   const d=WEEK[i], p=PLANS[d.type], col=ACCENT[d.type];
@@ -455,19 +562,33 @@ function select(i){
     p.chips.map(c=>`<span class="chip">${c}</span>`).join('');
 
   document.getElementById('d-ex').innerHTML = p.ex.map((e,k)=>`
-    <div class="ex-row">
+    <div class="ex-row" data-i="${k}" role="button" tabindex="0">
       <span class="ex-n">${k+1}</span>
       <span class="ex-name">${e.name}${e.sub?`<small>${e.sub}</small>`:''}</span>
       <span class="ex-vol">${e.vol.replace('×','<span>×</span>')}</span>
     </div>`).join('');
 
-  // muscle map
-  const all = p.muscles.includes('all');
-  figMs.forEach(m=>{
-    m.classList.remove('on','soft');
-    if(all){ m.classList.add('soft'); }
-    else if(p.muscles.includes(m.dataset.k)){ m.classList.add('on'); }
+  const rows = [...document.querySelectorAll('#d-ex .ex-row')];
+  rows.forEach(row=>{
+    const toggle = ()=>{
+      const wasActive = row.classList.contains('active');
+      rows.forEach(r=>r.classList.remove('active'));
+      if(wasActive){
+        showDayMuscles(p);
+        hideMoveInfo();
+      } else {
+        row.classList.add('active');
+        showExerciseDemo(p, p.ex[+row.dataset.i]);
+      }
+    };
+    row.addEventListener('click', toggle);
+    row.addEventListener('keydown', (e)=>{
+      if(e.key==='Enter' || e.key===' '){ e.preventDefault(); toggle(); }
+    });
   });
+
+  showDayMuscles(p);
+  hideMoveInfo();
 }
 
 select(0);


### PR DESCRIPTION
Tapping an exercise in the list now demos how to do it using the same body figure on the left:

- Highlights and animates only the muscles that exercise targets (bounce for press/pull/squat-type movements, rotate for curls and mobility rotations, slow pulse for holds/stretches/cardio)
- Dims the rest of the day's muscle group for context
- Shows a short instructional cue below the figures
- Tapping the exercise again returns to the default whole-day muscle view

Verified with headless screenshots — biceps highlight + cue text shows correctly for "Curl de bíceps con barra", and the panel reads "Toca un ejercicio para ver cómo hacerlo →" by default.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExucvRoaKcZbC3NZebVE2T)_